### PR TITLE
Fix style when card theme is specified

### DIFF
--- a/src/alarmo-card.ts
+++ b/src/alarmo-card.ts
@@ -450,7 +450,7 @@ export class AlarmoCard extends SubscribeMixin(LitElement) {
         font-weight: 500;
       }
       div.message .description span {
-        background: var(--card-background-color);
+        background: var(--ha-card-background, var(--card-background-color, white));
         padding-right: 5px;
       }
       div.message .description ha-icon {


### PR DESCRIPTION
When I installed and tested the card, I saw this label doesn't have the right background color, because I have a custom theme.
So this is the fix.

![image](https://user-images.githubusercontent.com/8930930/142275943-e669da7e-439d-4137-a597-fdf8b3ee0127.png)
