### PR TITLE
add option kiosk_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Configuration using UI mode:
 | `use_clear_icon`       | boolean | Optional     | Show icon (instead of text) in keypad for clearing code input.<br>Only useful if numerical code is used.       | `false`            |
 | `show_messages`        | boolean | Optional     | Show diagnostic messages in the card when alarm is triggered or cannot be armed.                               | `true`             |
 | `states`               | object  | Optional     | Customize the display of states in the card.<br>See [state configuration](#state-configuration).               |                    |
-
+| `kiosk_mode    `       | boolean | Optional     | Disable more-info tapping.                                                                                     | `false`            |
 ### State configuration 
 State configuration allows users to modify the displayed texts and buttons (where applicable) in the card corresponding to certain states.
 

--- a/src/alarmo-card-editor.ts
+++ b/src/alarmo-card-editor.ts
@@ -171,7 +171,7 @@ export class AlarmoCardEditor extends LitElement implements LovelaceCardEditor {
             <ha-switch
               .checked=${this._config!.kiosk_mode}
               @change=${(ev: Event) => this._updateConfig('kiosk_mode', (ev.target as HTMLInputElement).checked)}
-              ?disabled=${!stateObj || !hasKeypad}
+              ?disabled=${!stateObj}
             ></ha-switch
           ></ha-formfield>
 

--- a/src/alarmo-card-editor.ts
+++ b/src/alarmo-card-editor.ts
@@ -167,6 +167,14 @@ export class AlarmoCardEditor extends LitElement implements LovelaceCardEditor {
             ></ha-switch
           ></ha-formfield>
 
+          <ha-formfield .label=${localize('editor.kiosk_mode', this.hass.language)}>
+            <ha-switch
+              .checked=${this._config!.kiosk_mode}
+              @change=${(ev: Event) => this._updateConfig('kiosk_mode', (ev.target as HTMLInputElement).checked)}
+              ?disabled=${!stateObj || !hasKeypad}
+            ></ha-switch
+          ></ha-formfield>
+
           <ha-formfield .label=${localize('editor.show_messages', this.hass.language)}>
             <ha-switch
               .checked=${this._config!.show_messages || !isDefined(this._config!.show_messages)}

--- a/src/alarmo-card.ts
+++ b/src/alarmo-card.ts
@@ -267,7 +267,9 @@ export class AlarmoCard extends SubscribeMixin(LitElement) {
             <alarmo-state-badge
               .hass=${this.hass}
               .entity=${this._config.entity}
-              @click=${() => fireEvent(this, 'hass-more-info', { entityId: this._config!.entity })}
+              @click=${this._config.kiosk_mode
+              ? void(0)
+              : () => fireEvent(this, 'hass-more-info', { entityId: this._config!.entity })}
             >
             </alarmo-state-badge>
           </div>
@@ -395,7 +397,7 @@ export class AlarmoCard extends SubscribeMixin(LitElement) {
                 if (!this.subscribedEntities.includes(e)) this.subscribedEntities.push(e);
                 return html`
                   <div class="badge">
-                    <alarmo-sensor-badge .hass=${this.hass} .entity=${e}> </alarmo-sensor-badge>
+                    <alarmo-sensor-badge .hass=${this.hass} .entity=${e} .config=${this._config}> </alarmo-sensor-badge>
                   </div>
                 `;
               })}

--- a/src/components/alarmo-sensor-badge.ts
+++ b/src/components/alarmo-sensor-badge.ts
@@ -63,9 +63,9 @@ class AlarmoSensorBadge extends LitElement {
         <div class="title">${name}-</div>
       </div>
     `
-    }
+  }
 
-    static get styles(): CSSResult {
+  static get styles(): CSSResult {
     return css`
       .badge-container {
         display: inline-block;

--- a/src/components/alarmo-sensor-badge.ts
+++ b/src/components/alarmo-sensor-badge.ts
@@ -10,6 +10,7 @@ import {
   NumberFormat,
 } from 'custom-card-helpers';
 import { HassEntity } from 'home-assistant-js-websocket';
+import { CardConfig } from '../types';
 
 class AlarmoSensorBadge extends LitElement {
   @property()
@@ -20,6 +21,9 @@ class AlarmoSensorBadge extends LitElement {
 
   @property()
   public state?: string;
+
+  @property()
+  public config?: CardConfig;
 
   shouldUpdate(changedProps: PropertyValues) {
     const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
@@ -43,7 +47,11 @@ class AlarmoSensorBadge extends LitElement {
     let binaryState = this.state ? true : stateObj.state == 'on';
 
     return html`
-      <div class="badge-container" @click=${() => fireEvent(this, 'hass-more-info', { entityId: this.entity! })}>
+      <div class="badge-container"
+        ${ !this.config?.kiosk_mode
+          ? html`@click=${() => fireEvent(this, 'hass-more-info', { entityId: this.entity! })}>`
+         : '' }
+      >
         <div class="label-badge ${binaryState ? 'active' : ''}" id="badge">
           <div class="value">
             <ha-icon .icon=${icon}></ha-icon>
@@ -52,12 +60,12 @@ class AlarmoSensorBadge extends LitElement {
             </div>
           </div>
         </div>
-        <div class="title">${name}</div>
+        <div class="title">${name}-</div>
       </div>
-    `;
-  }
+    `
+    }
 
-  static get styles(): CSSResult {
+    static get styles(): CSSResult {
     return css`
       .badge-container {
         display: inline-block;

--- a/src/const.ts
+++ b/src/const.ts
@@ -72,6 +72,7 @@ export const defaultCardConfig: CardConfig = {
   button_scale_keypad: 1,
   states: {},
   show_messages: true,
+  kiosk_mode: false,
 };
 
 export const minButtonScale = 1;

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -10,6 +10,7 @@
     "button_scale_keypad": "Skalierungsfaktor für Buttongröße der Pin-Eingabefeld.",
     "use_clear_icon": "Show icon (instead of text) in keypad for clearing code input.",
     "show_messages": "Display diagnostic messages when alarm is triggered or cannot be armed.",
+    "kiosk_mode": "Disable more-info tapping.",
     "available_actions": "Available actions:",
     "action_dialog": {
       "title": "Customize display of action '{action}'",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -10,6 +10,7 @@
     "button_scale_keypad": "Scaling factor to apply for resizing the keypad buttons.",
     "use_clear_icon": "Show icon (instead of text) in keypad for clearing code input.",
     "show_messages": "Display diagnostic messages when alarm is triggered or cannot be armed.",
+    "kiosk_mode": "Disable more-info tapping.",
     "available_actions": "Available actions:",
     "action_dialog": {
       "title": "Customize display of action '{action}'",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -11,6 +11,7 @@
     "button_scale_keypad": "Factor de escalado para cambiar el tamaño de los botones del teclado.",
     "use_clear_icon": "Mostrar icono (en lugar de texto) en el teclado para borrar la entrada de código.",
     "show_messages": "Mostrar mensajes de diagnóstico cuando se activa la alarma o no se puede activar.",
+    "kiosk_mode": "Disable more-info tapping.",
     "available_actions": "Acciones disponibles:",
     "action_dialog": {
       "title": "Personalizar la visualización de la acción '{action}'",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -10,6 +10,7 @@
     "button_scale_keypad": "Facteur d'échelle à appliquer pour le redimensionnement des boutons du clavier.",
     "use_clear_icon": "Afficher l'icône (au lieu du texte) sur le clavier pour effacer la saisie du code.",
     "show_messages": "Afficher les messages de diagnostic lorsque l'alarme est déclenchée ou ne peut pas être armée.",
+    "kiosk_mode": "Disable more-info tapping.",
     "available_actions": "Actions disponibles:",
     "action_dialog": {
       "title": "Personnaliser l'affichage de l'action '{action}'",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type CardConfig = {
   button_scale_actions: number;
   states: Partial<Record<AlarmStates, StateConfig>>;
   show_messages: boolean;
+  kiosk_mode: boolean;
 };
 
 export type StateConfig = {


### PR DESCRIPTION
I needed to disable more-info/history click/tap when use with "kiosk".

Now there is kiosk_mode option.
**kiosk_mode:** _true_ = Do not enable more-info/history -view.
Default value is _false_
