### PR TITLE
Add pt-br language

### DIFF
--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -1,0 +1,28 @@
+{
+  "arm_options": {
+    "heading": "Opções para armar",
+    "skip_delay": "Omitir tempo para sair",
+    "force": "Ignorar os sensores abertos"
+  },
+  "editor": {
+    "keep_keypad_visible": "Mantenha o teclado sempre visível, mesmo quando não for necessária nenhuma entrada de código.",
+    "button_scale_actions": "Fator de escala para redimensionar botões de ação.",
+    "button_scale_keypad": "Fator de escala para redimensionar os botões do teclado.",
+    "use_clear_icon": "Mostre o ícone (em vez de texto) no teclado para limpar a entrada do código.",
+    "show_messages": "Mostrar mensagens de diagnóstico quando o alarme estiver disparado ou não puder ser armado.",
+    "show_ready_indicator": "Mostrar indicador de disponível/não disponível nos botões do modo de armar.",
+    "show_bypassed_sensors": "Mostrar aviso quando o alarme for ativado com sensores ignorados.",
+    "available_actions": "Ações disponíveis:",
+    "action_dialog": {
+      "title": "Personalize a exibição da ação '{action}'",
+      "show_button": "Mostrar botão para esta ação",
+      "button_label": "Substituir texto do botão",
+      "state_label": "Substituir texto de status"
+    }
+  },
+  "errors": {
+    "blocking_sensors": "Não foi possível armar devido aos seguintes sensores",
+    "triggered_sensors": "O alarme foi disparado pelos seguintes sensores",
+    "bypassed_sensors": "Existem sensores ignorados"
+  }
+}

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -4,6 +4,7 @@ import * as es from './languages/es.json';
 import * as fr from './languages/fr.json';
 import * as it from './languages/it.json';
 import * as nl from './languages/nl.json';
+import * as pt_Br from './languages/pt-BR.json'
 import * as zh_Hans from './languages/zh-Hans.json';
 
 var languages: any = {
@@ -13,6 +14,7 @@ var languages: any = {
   fr: fr,
   it: it,
   nl: nl,
+  'pt-BR': pt_Br,
   'zh-Hans': zh_Hans,
 };
 


### PR DESCRIPTION
I added the Brazilian Portuguese language file., but I'm not a frontend dev and I don't know much about javascript/node/npm. I couldn't build the application to test, I always get this error:
![image](https://github.com/nielsfaber/alarmo-card/assets/3594149/c6c54c77-a8f9-42ae-936e-c76895fcfb7f)

After changing the .eslintrc file to .eslintrc.js, it passed this step, but it reports a lint error in other files that I didn't change: 
![image](https://github.com/nielsfaber/alarmo-card/assets/3594149/b6e34db1-fdb7-4f98-a422-d4154aaf243a)

I tried ignoring the lint and just running the build to test, but I get the following error:
![image](https://github.com/nielsfaber/alarmo-card/assets/3594149/eaa511e3-60e7-41f5-bb7a-8041d64907f1)

Could you help me before incorporating the translation?

I don't know if it could be the versions I'm using or something. I'm using:

nodejs: 18.19.1
